### PR TITLE
Implement deficit longest prefix match scheduler

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -151,6 +151,7 @@ class OpenAIServingChat(OpenAIServingBase):
             rid=request.rid,
             priority=request.priority,
             customer_labels=customer_labels,
+            user=request.user,
         )
 
         return adapted_request, request

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -615,6 +615,9 @@ class TokenizedGenerateReqInput:
     # tracing context
     trace_context: Optional[Dict] = None
 
+    # User identifier for client tracking
+    user: Optional[str] = None
+
 
 @dataclass
 class BatchTokenizedGenerateReqInput:

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -144,6 +144,9 @@ class GenerateReqInput:
     # For customer metric labels
     customer_labels: Optional[Dict[str, str]] = None
 
+    # User identifier for client tracking
+    user: Optional[str] = None
+
     def contains_mm_input(self) -> bool:
         return (
             has_valid_data(self.image_data)

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -64,6 +64,7 @@ class CacheAwarePolicy(Enum):
     """Scheduling policies that are aware of the tree cache."""
 
     LPM = "lpm"  # longest prefix match
+    DLPM = "dlpm"  # deficit longest prefix match (fair LPM)
     DFS_WEIGHT = "dfs-weight"  # depth-first search weighting
 
 
@@ -116,7 +117,7 @@ class SchedulePolicy:
             temporary_deprioritized = self._compute_prefix_matches(
                 waiting_queue, policy
             )
-            if policy == CacheAwarePolicy.LPM:
+            if policy == CacheAwarePolicy.LPM or policy == CacheAwarePolicy.DLPM:
                 SchedulePolicy._sort_by_longest_prefix(
                     waiting_queue, temporary_deprioritized
                 )
@@ -140,7 +141,7 @@ class SchedulePolicy:
         return prefix_computed
 
     def _determine_active_policy(self, waiting_queue: List[Req]) -> Policy:
-        if self.policy == CacheAwarePolicy.LPM and len(waiting_queue) > 128:
+        if (self.policy == CacheAwarePolicy.LPM or self.policy == CacheAwarePolicy.DLPM) and len(waiting_queue) > 128:
             # Turn off the expensive prefix matching and sorting when the #queue is large.
             return CacheAgnosticPolicy.FCFS
         return self.policy

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1491,6 +1491,11 @@ class Scheduler(
                     if deficit <= 0:
                         self.dlpm_client_deficits[client_id] += DLPM_CLIENT_QUANTUM
 
+    def _update_dlpm_metrics(self):
+        """Update DLPM-specific metrics."""
+        if self.policy.policy == CacheAwarePolicy.DLPM:
+            self.stats.dlpm_num_clients = len(self.dlpm_client_deficits)
+
     def _acknowledge_admission(self, req: Req):
         """
         Called when a request is successfully admitted to the batch. Most

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1261,6 +1261,7 @@ class Scheduler(
                 metrics_collector=(
                     self.metrics_collector if self.enable_metrics else None
                 ),
+                session_id=recv_req.user,
             )
             req.tokenizer = self.tokenizer
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -20,7 +20,7 @@ import signal
 import sys
 import threading
 import time
-from collections import deque
+from collections import defaultdict, deque
 from concurrent import futures
 from dataclasses import dataclass
 from http import HTTPStatus
@@ -34,10 +34,6 @@ import zmq
 from torch.distributed import barrier
 
 from sglang.global_config import global_config
-
-# DLPM configuration constants
-DLPM_CLIENT_QUANTUM = 2500  # Default deficit refill value per client
-DLPM_PREFILL_TOKEN_COST = 0.6  # Cost multiplier for prefill tokens (60% of decode token cost)
 
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.constrained.base_grammar_backend import (
@@ -194,6 +190,10 @@ from sglang.utils import TypeBasedDispatcher, get_exception_traceback
 
 logger = logging.getLogger(__name__)
 
+# DLPM configuration constants
+DLPM_CLIENT_QUANTUM = 2500  # Default deficit refill value per client
+DLPM_PREFILL_TOKEN_COST = 0.6  # Cost multiplier for prefill tokens (60% of decode token cost)
+
 # Test retract decode for debugging purposes
 TEST_RETRACT = get_bool_env_var("SGLANG_TEST_RETRACT")
 GRAMMAR_TIMEOUT = float(os.environ.get("SGLANG_GRAMMAR_TIMEOUT", 300))
@@ -216,6 +216,24 @@ class GenerationBatchResult:
 class EmbeddingBatchResult:
     embeddings: torch.Tensor
     bid: int
+
+
+@dataclass
+class DLPMClient:
+    """Tracks DLPM state for a single client."""
+    deficit: int = 0
+    last_seen: float = 0
+
+    def seen(self) -> None:
+        self.last_seen = time.perf_counter()
+
+    def consume_tokens(self, tokens: int) -> None:
+        self.deficit -= tokens
+        self.seen()
+
+    def refill(self) -> None:
+        self.deficit += DLPM_CLIENT_QUANTUM
+        self.seen()
 
 
 class Scheduler(
@@ -483,9 +501,8 @@ class Scheduler(
         self.kv_transfer_latency_ms: float = 0.0
         self.sessions: Dict[str, Session] = {}
 
-        # DLPM state: per-client deficit counters and timestamps
-        self.dlpm_client_deficits: Dict[str, int] = {}
-        self.dlpm_client_timestamps: Dict[str, float] = {}
+        # DLPM state: per-client tracking
+        self.dlpm_clients: Dict[str, DLPMClient] = defaultdict(DLPMClient)
         self.current_stream = torch.get_device_module(self.device).current_stream()
         if self.device == "cpu":
             self.current_stream.synchronize = lambda: None  # No-op for CPU
@@ -1425,13 +1442,8 @@ class Scheduler(
             # DLPM client initialization and state update
             if self.policy.policy == CacheAwarePolicy.DLPM:
                 client_id = req.session_id if req.session_id else '<anonymous>'
-
-                # Update last seen timestamp
-                self.dlpm_client_timestamps[client_id] = time.perf_counter()
-
-                # Initialize deficit counter for new clients
-                if client_id not in self.dlpm_client_deficits:
-                    self.dlpm_client_deficits[client_id] = 0
+                # Initialize/update client state
+                self.dlpm_clients[client_id].seen()
 
             self._prefetch_kvcache(req)
             self.waiting_queue.append(req)
@@ -1479,7 +1491,8 @@ class Scheduler(
                 client_id = req.session_id or '<anonymous>'
 
                 # Only admit requests from clients with positive deficits
-                if self.dlpm_client_deficits.setdefault(client_id, 0) > 0:
+                client = self.dlpm_clients[client_id]
+                if client.deficit > 0:
                     yield req
                     remaining_requests.remove(req)
                     admitted_any = True
@@ -1487,9 +1500,9 @@ class Scheduler(
             # If we went through all requests but couldn't admit *any*, ...
             if not admitted_any and remaining_requests:
                 # refill ALL known clients with no remaining credits.
-                for client_id, deficit in self.dlpm_client_deficits.items():
-                    if deficit <= 0:
-                        self.dlpm_client_deficits[client_id] += DLPM_CLIENT_QUANTUM
+                for client in self.dlpm_clients.values():
+                    if client.deficit <= 0:
+                        client.refill()
 
     def _cleanup_inactive_dlpm_clients(self):
         """Remove DLPM client state for clients that haven't been seen in an hour."""
@@ -1497,16 +1510,13 @@ class Scheduler(
             return
 
         current_time = time.perf_counter()
-        inactive_clients = []
+        inactive_clients = [
+            client_id for client_id, client in self.dlpm_clients.items()
+            if current_time - client.last_seen > 3600
+        ]
 
-        for client_id, last_seen in self.dlpm_client_timestamps.items():
-            if current_time - last_seen > 3600:  # 1 hour timeout
-                inactive_clients.append(client_id)
-
-        # Remove inactive clients from all tracking dictionaries
         for client_id in inactive_clients:
-            self.dlpm_client_deficits.pop(client_id, None)
-            self.dlpm_client_timestamps.pop(client_id, None)
+            del self.dlpm_clients[client_id]
 
         if inactive_clients:
             logger.info(f"Cleaned up {len(inactive_clients)} inactive DLPM clients: {inactive_clients}")
@@ -1514,7 +1524,7 @@ class Scheduler(
     def _update_dlpm_metrics(self):
         """Update DLPM-specific metrics."""
         if self.policy.policy == CacheAwarePolicy.DLPM:
-            self.stats.dlpm_num_clients = len(self.dlpm_client_deficits)
+            self.stats.dlpm_num_clients = len(self.dlpm_clients)
 
     def _acknowledge_admission(self, req: Req):
         """
@@ -1526,7 +1536,8 @@ class Scheduler(
             client_id = req.session_id or '<anonymous>'
             # Subtract extend tokens from client's deficit (with prefill cost multiplier)
             prefill_token_cost = int(req.extend_input_len * DLPM_PREFILL_TOKEN_COST)
-            self.dlpm_client_deficits[client_id] -= prefill_token_cost
+            client = self.dlpm_clients[client_id]
+            client.consume_tokens(prefill_token_cost)
 
     def _extend_requests_to_queue(self, reqs: List[Req], is_retracted: bool = False):
         if self.disaggregation_mode == DisaggregationMode.PREFILL:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1479,7 +1479,7 @@ class Scheduler(
                 client_id = req.session_id or '<anonymous>'
 
                 # Only admit requests from clients with positive deficits
-                if self.dlpm_client_deficits.get(client_id, 0) > 0:
+                if self.dlpm_client_deficits.setdefault(client_id, 0) > 0:
                     yield req
                     remaining_requests.remove(req)
                     admitted_any = True

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1555,12 +1555,15 @@ class Scheduler(
                 self.dlpm_last_metrics_update = current_time
 
                 client_tuples = []
+                active_client_count = 0
                 for client_id, client in self.dlpm_clients.items():
                     delta = client.get_token_delta()
                     if delta > 0:
                         client_tuples.append((client_id, delta))
+                        active_client_count += 1
 
                 self.stats.dlpm_top_clients = heapq.nlargest(10, client_tuples, key=lambda c: c[1])
+                self.stats.dlpm_active_clients = active_client_count
                 self.stats.dlpm_needs_flush = True
 
     def _acknowledge_admission(self, req: Req):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1547,6 +1547,7 @@ class Scheduler(
                         client_tuples.append((client_id, delta))
 
                 self.stats.dlpm_top_clients = heapq.nlargest(10, client_tuples, key=lambda c: c[1])
+                self.stats.dlpm_needs_flush = True
 
     def _acknowledge_admission(self, req: Req):
         """

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1491,27 +1491,41 @@ class Scheduler(
         """
         remaining_requests = waiting_queue.copy()
 
-        while remaining_requests:
-            # Make a copy for iteration since we might modify remaining_requests
-            current_pass_requests = remaining_requests.copy()
-            admitted_any = False
+        # track the maximum number of refills we had to do before any client
+        # could progress, giving a sort of "fairness pressure" signal
+        refills_needed = 0
+        current_refill_streak = 0
 
-            for req in current_pass_requests:
-                client_id = req.session_id or '<anonymous>'
+        try:
+            while remaining_requests:
+                # Make a copy for iteration since we might modify remaining_requests
+                current_pass_requests = remaining_requests.copy()
+                admitted_any = False
 
-                # Only admit requests from clients with positive deficits
-                client = self.dlpm_clients[client_id]
-                if client.deficit > 0:
-                    yield req
-                    remaining_requests.remove(req)
-                    admitted_any = True
+                for req in current_pass_requests:
+                    client_id = req.session_id or '<anonymous>'
 
-            # If we went through all requests but couldn't admit *any*, ...
-            if not admitted_any and remaining_requests:
-                # refill ALL known clients with no remaining credits.
-                for client in self.dlpm_clients.values():
-                    if client.deficit <= 0:
-                        client.refill()
+                    # Only admit requests from clients with positive deficits
+                    client = self.dlpm_clients[client_id]
+                    if client.deficit > 0:
+                        if current_refill_streak > 0:
+                            refills_needed = max(refills_needed, current_refill_streak)
+                            current_refill_streak = 0
+
+                        yield req
+                        remaining_requests.remove(req)
+                        admitted_any = True
+
+                # If no requests could be admitted, refill ALL deficits
+                # (including for backlogged clients not currently in the queue).
+                if not admitted_any and remaining_requests:
+                    for client in self.dlpm_clients.values():
+                        if client.deficit <= 0:
+                            client.refill()
+                    current_refill_streak += 1
+
+        finally:
+            self.stats.dlpm_refills_needed = refills_needed
 
     def _cleanup_inactive_dlpm_clients(self):
         """Remove DLPM client state for clients that haven't been seen in an hour."""

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1491,6 +1491,26 @@ class Scheduler(
                     if deficit <= 0:
                         self.dlpm_client_deficits[client_id] += DLPM_CLIENT_QUANTUM
 
+    def _cleanup_inactive_dlpm_clients(self):
+        """Remove DLPM client state for clients that haven't been seen in an hour."""
+        if self.policy.policy != CacheAwarePolicy.DLPM:
+            return
+
+        current_time = time.perf_counter()
+        inactive_clients = []
+
+        for client_id, last_seen in self.dlpm_client_timestamps.items():
+            if current_time - last_seen > 3600:  # 1 hour timeout
+                inactive_clients.append(client_id)
+
+        # Remove inactive clients from all tracking dictionaries
+        for client_id in inactive_clients:
+            self.dlpm_client_deficits.pop(client_id, None)
+            self.dlpm_client_timestamps.pop(client_id, None)
+
+        if inactive_clients:
+            logger.info(f"Cleaned up {len(inactive_clients)} inactive DLPM clients: {inactive_clients}")
+
     def _update_dlpm_metrics(self):
         """Update DLPM-specific metrics."""
         if self.policy.policy == CacheAwarePolicy.DLPM:
@@ -1645,6 +1665,7 @@ class Scheduler(
     def self_check_during_idle(self):
         self.check_memory()
         self.check_tree_cache()
+        self._cleanup_inactive_dlpm_clients()
         self.new_token_ratio = self.init_new_token_ratio
         self.maybe_sleep_on_idle()
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -128,6 +128,7 @@ from sglang.srt.managers.schedule_batch import (
 )
 from sglang.srt.managers.schedule_policy import (
     AddReqResult,
+    CacheAwarePolicy,
     PrefillAdder,
     SchedulePolicy,
 )

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -34,6 +34,9 @@ import zmq
 from torch.distributed import barrier
 
 from sglang.global_config import global_config
+
+# DLPM configuration constants
+DLPM_CLIENT_QUANTUM = 2500  # Default deficit refill value per client
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.constrained.base_grammar_backend import (
     INVALID_GRAMMAR_OBJ,
@@ -1456,13 +1459,14 @@ class Scheduler(
 
     def _acknowledge_admission(self, req: Req):
         """
-        Called when a request is successfully admitted to the batch.
-
-        For non-DLPM policies, this does nothing.
-        For DLPM, this will subtract extend tokens from the client's deficit.
+        Called when a request is successfully admitted to the batch. Most
+        policies do not need this information, but DLPM uses it for accounting
+        token costs.
         """
-        # For non-DLPM policies, no admission accounting needed
-        pass
+        if self.policy.policy == CacheAwarePolicy.DLPM:
+            client_id = req.session_id or '<anonymous>'
+            # Subtract extend tokens from client's deficit
+            self.dlpm_client_deficits[client_id] -= req.extend_input_len
 
     def _extend_requests_to_queue(self, reqs: List[Req], is_retracted: bool = False):
         if self.disaggregation_mode == DisaggregationMode.PREFILL:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1450,12 +1450,43 @@ class Scheduler(
     def _get_admission_iterator(self, waiting_queue: List[Req]):
         """
         Generator that yields requests for admission based on the scheduling policy.
-
-        For now, this just iterates through the waiting_queue as before.
-        Later, DLPM will implement deficit-based admission logic here.
         """
-        # For all non-DLPM policies, just iterate through the queue as before
-        return iter(waiting_queue)
+        if self.policy.policy != CacheAwarePolicy.DLPM:
+            # For non-DLPM policies, just iterate through the queue as before
+            return iter(waiting_queue)
+
+        # DLPM deficit-based admission logic
+        return self._dlpm_admission_iterator(waiting_queue)
+
+    def _dlpm_admission_iterator(self, waiting_queue: List[Req]):
+        """
+        DLPM admission iterator that implements deficit-based admission with refill logic.
+
+        Yields requests from clients with positive deficits. If no clients can be admitted
+        in a full pass through the queue, refills all client deficits and continues.
+        """
+        remaining_requests = waiting_queue.copy()
+
+        while remaining_requests:
+            # Make a copy for iteration since we might modify remaining_requests
+            current_pass_requests = remaining_requests.copy()
+            admitted_any = False
+
+            for req in current_pass_requests:
+                client_id = req.session_id or '<anonymous>'
+
+                # Only admit requests from clients with positive deficits
+                if self.dlpm_client_deficits.get(client_id, 0) > 0:
+                    yield req
+                    remaining_requests.remove(req)
+                    admitted_any = True
+
+            # If we went through all requests but couldn't admit *any*, ...
+            if not admitted_any and remaining_requests:
+                # refill ALL known clients with no remaining credits.
+                for client_id, deficit in self.dlpm_client_deficits.items():
+                    if deficit <= 0:
+                        self.dlpm_client_deficits[client_id] += DLPM_CLIENT_QUANTUM
 
     def _acknowledge_admission(self, req: Req):
         """

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -14,6 +14,7 @@
 """A scheduler that manages a tensor parallel GPU worker."""
 
 import faulthandler
+import heapq
 import logging
 import os
 import signal
@@ -223,17 +224,24 @@ class DLPMClient:
     """Tracks DLPM state for a single client."""
     deficit: int = 0
     last_seen: float = 0
+    token_delta: int = 0
 
     def seen(self) -> None:
         self.last_seen = time.perf_counter()
 
     def consume_tokens(self, tokens: int) -> None:
         self.deficit -= tokens
+        self.token_delta += tokens
         self.seen()
 
     def refill(self) -> None:
         self.deficit += DLPM_CLIENT_QUANTUM
         self.seen()
+
+    def get_token_delta(self) -> int:
+        d = self.token_delta
+        self.token_delta = 0
+        return d
 
 
 class Scheduler(
@@ -503,6 +511,7 @@ class Scheduler(
 
         # DLPM state: per-client tracking
         self.dlpm_clients: Dict[str, DLPMClient] = defaultdict(DLPMClient)
+        self.dlpm_last_metrics_update: float = time.perf_counter()
         self.current_stream = torch.get_device_module(self.device).current_stream()
         if self.device == "cpu":
             self.current_stream.synchronize = lambda: None  # No-op for CPU
@@ -1525,6 +1534,19 @@ class Scheduler(
         """Update DLPM-specific metrics."""
         if self.policy.policy == CacheAwarePolicy.DLPM:
             self.stats.dlpm_num_clients = len(self.dlpm_clients)
+
+            # Only update top clients metric once per minute
+            current_time = time.perf_counter()
+            if current_time - self.dlpm_last_metrics_update >= 60:
+                self.dlpm_last_metrics_update = current_time
+
+                client_tuples = []
+                for client_id, client in self.dlpm_clients.items():
+                    delta = client.get_token_delta()
+                    if delta > 0:
+                        client_tuples.append((client_id, delta))
+
+                self.stats.dlpm_top_clients = heapq.nlargest(10, client_tuples, key=lambda c: c[1])
 
     def _acknowledge_admission(self, req: Req):
         """

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1444,6 +1444,26 @@ class Scheduler(
                     req.rid, req.last_host_node, new_input_tokens, last_hash
                 )
 
+    def _get_admission_iterator(self, waiting_queue: List[Req]):
+        """
+        Generator that yields requests for admission based on the scheduling policy.
+
+        For now, this just iterates through the waiting_queue as before.
+        Later, DLPM will implement deficit-based admission logic here.
+        """
+        # For all non-DLPM policies, just iterate through the queue as before
+        return iter(waiting_queue)
+
+    def _acknowledge_admission(self, req: Req):
+        """
+        Called when a request is successfully admitted to the batch.
+
+        For non-DLPM policies, this does nothing.
+        For DLPM, this will subtract extend tokens from the client's deficit.
+        """
+        # For non-DLPM policies, no admission accounting needed
+        pass
+
     def _extend_requests_to_queue(self, reqs: List[Req], is_retracted: bool = False):
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             self.disagg_prefill_bootstrap_queue.extend(
@@ -1840,7 +1860,8 @@ class Scheduler(
             lora_set = set([req.lora_id for req in self.running_batch.reqs])
 
         # Get requests from the waiting queue to a new prefill batch
-        for req in self.waiting_queue:
+        admission_iterator = self._get_admission_iterator(self.waiting_queue)
+        for req in admission_iterator:
 
             if self.enable_lora and not self.tp_worker.can_run_lora_batch(
                 lora_set
@@ -1878,7 +1899,10 @@ class Scheduler(
                 truncation_align_size=self.truncation_align_size,
             )
 
-            if res != AddReqResult.CONTINUE:
+            if res == AddReqResult.CONTINUE:
+                # Request successfully admitted - acknowledge for policy accounting
+                self._acknowledge_admission(req)
+            else:
                 if res == AddReqResult.NO_TOKEN:
                     if self.enable_hierarchical_cache:
                         # Set batch_is_full after making sure there are requests that can be served

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -37,6 +37,8 @@ from sglang.global_config import global_config
 
 # DLPM configuration constants
 DLPM_CLIENT_QUANTUM = 2500  # Default deficit refill value per client
+DLPM_PREFILL_TOKEN_COST = 0.6  # Cost multiplier for prefill tokens (60% of decode token cost)
+
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.constrained.base_grammar_backend import (
     INVALID_GRAMMAR_OBJ,
@@ -1496,8 +1498,9 @@ class Scheduler(
         """
         if self.policy.policy == CacheAwarePolicy.DLPM:
             client_id = req.session_id or '<anonymous>'
-            # Subtract extend tokens from client's deficit
-            self.dlpm_client_deficits[client_id] -= req.extend_input_len
+            # Subtract extend tokens from client's deficit (with prefill cost multiplier)
+            prefill_token_cost = int(req.extend_input_len * DLPM_PREFILL_TOKEN_COST)
+            self.dlpm_client_deficits[client_id] -= prefill_token_cost
 
     def _extend_requests_to_queue(self, reqs: List[Req], is_retracted: bool = False):
         if self.disaggregation_mode == DisaggregationMode.PREFILL:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -476,6 +476,10 @@ class Scheduler(
         self.kv_transfer_speed_gb_s: float = 0.0
         self.kv_transfer_latency_ms: float = 0.0
         self.sessions: Dict[str, Session] = {}
+
+        # DLPM state: per-client deficit counters and timestamps
+        self.dlpm_client_deficits: Dict[str, int] = {}
+        self.dlpm_client_timestamps: Dict[str, float] = {}
         self.current_stream = torch.get_device_module(self.device).current_stream()
         if self.device == "cpu":
             self.current_stream.synchronize = lambda: None  # No-op for CPU
@@ -1411,6 +1415,18 @@ class Scheduler(
             self._set_or_validate_priority(req)
             if self._abort_on_queued_limit(req):
                 return
+
+            # DLPM client initialization and state update
+            if self.policy.policy == CacheAwarePolicy.DLPM:
+                client_id = req.session_id if req.session_id else '<anonymous>'
+
+                # Update last seen timestamp
+                self.dlpm_client_timestamps[client_id] = time.perf_counter()
+
+                # Initialize deficit counter for new clients
+                if client_id not in self.dlpm_client_deficits:
+                    self.dlpm_client_deficits[client_id] = 0
+
             self._prefetch_kvcache(req)
             self.waiting_queue.append(req)
             trace_slice_end("process req", req.rid, auto_next_anon=True)

--- a/python/sglang/srt/managers/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/managers/scheduler_metrics_mixin.py
@@ -146,6 +146,9 @@ class SchedulerMetricsMixin:
                 total_queue_latency += req.queue_time_end - req.queue_time_start
             self.stats.avg_request_queue_latency = total_queue_latency / num_new_seq
 
+            # DLPM metrics - update only during prefill (scheduling decisions)
+            self._update_dlpm_metrics()
+
             if self.disaggregation_mode == DisaggregationMode.PREFILL:
                 self.stats.num_prefill_prealloc_queue_reqs = len(
                     self.disagg_prefill_bootstrap_queue.queue

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -248,10 +248,22 @@ class SchedulerOutputProcessorMixin:
                 # speculative worker will solve the output_ids in speculative decoding
                 req.output_ids.append(next_token_id)
 
+                # DLPM decode token accounting
+                if self.policy.policy == CacheAwarePolicy.DLPM:
+                    client_id = req.session_id or '<anonymous>'
+                    # Subtract 1 token from client's deficit for each generated token
+                    self.dlpm_client_deficits[client_id] -= 1
+
             req.check_finished()
             if req.finished():
                 self.tree_cache.cache_finished_req(req)
                 req.time_stats.completion_time = time.time()
+
+                # DLPM speculative decode token accounting - bill when request is complete
+                if self.policy.policy == CacheAwarePolicy.DLPM and not batch.spec_algorithm.is_none():
+                    client_id = req.session_id or '<anonymous>'
+                    total_completion_tokens = len(req.output_ids)
+                    self.dlpm_client_deficits[client_id] -= total_completion_tokens
 
             if req.return_logprob and batch.spec_algorithm.is_none():
                 # speculative worker handles logprob in speculative decoding

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -11,6 +11,7 @@ from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.managers.io_struct import AbortReq, BatchEmbeddingOut, BatchTokenIDOut
 from sglang.srt.managers.schedule_batch import BaseFinishReason, Req, ScheduleBatch
+from sglang.srt.managers.schedule_policy import CacheAwarePolicy
 
 if TYPE_CHECKING:
     from sglang.srt.managers.scheduler import (

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -252,8 +252,7 @@ class SchedulerOutputProcessorMixin:
                 # DLPM decode token accounting
                 if self.policy.policy == CacheAwarePolicy.DLPM:
                     client_id = req.session_id or '<anonymous>'
-                    # Subtract 1 token from client's deficit for each generated token
-                    self.dlpm_client_deficits[client_id] -= 1
+                    self.dlpm_clients[client_id].consume_tokens(1)
 
             req.check_finished()
             if req.finished():
@@ -264,7 +263,7 @@ class SchedulerOutputProcessorMixin:
                 if self.policy.policy == CacheAwarePolicy.DLPM and not batch.spec_algorithm.is_none():
                     client_id = req.session_id or '<anonymous>'
                     total_completion_tokens = len(req.output_ids)
-                    self.dlpm_client_deficits[client_id] -= total_completion_tokens
+                    self.dlpm_clients[client_id].consume_tokens(total_completion_tokens)
 
             if req.return_logprob and batch.spec_algorithm.is_none():
                 # speculative worker handles logprob in speculative decoding

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -750,6 +750,7 @@ class TokenizerManager(TokenizerCommunicatorMixin):
                 return_hidden_states=obj.return_hidden_states,
                 data_parallel_rank=obj.data_parallel_rank,
                 priority=obj.priority,
+                user=obj.user,
             )
         elif isinstance(obj, EmbeddingReqInput):
             tokenized_obj = TokenizedEmbeddingReqInput(

--- a/python/sglang/srt/metrics/collector.py
+++ b/python/sglang/srt/metrics/collector.py
@@ -177,6 +177,7 @@ class SchedulerStats:
     dlpm_top_clients: List[Tuple[str, int]] = field(default_factory=list)
     dlpm_needs_flush: bool = False
     dlpm_refills_needed: int = 0
+    dlpm_active_clients: int = 0
 
 class SchedulerMetricsCollector:
 
@@ -369,6 +370,12 @@ class SchedulerMetricsCollector:
         self.dlpm_refills_needed = Gauge(
             name="sglang:dlpm_refills_needed",
             documentation="The most refills needed before progress could be made.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.dlpm_active_clients = Gauge(
+            name="sglang:dlpm_active_clients",
+            documentation="The number of active clients with positive token consumption in the current window.",
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
@@ -622,6 +629,7 @@ class SchedulerMetricsCollector:
         # DLPM metrics
         self._log_gauge(self.dlpm_num_clients, stats.dlpm_num_clients)
         self._log_gauge(self.dlpm_refills_needed, stats.dlpm_refills_needed)
+        self._log_gauge(self.dlpm_active_clients, stats.dlpm_active_clients)
 
         if stats.dlpm_needs_flush:
             stats.dlpm_needs_flush = False

--- a/python/sglang/srt/metrics/collector.py
+++ b/python/sglang/srt/metrics/collector.py
@@ -172,6 +172,9 @@ class SchedulerStats:
     engine_startup_time: float = 0.0
     engine_load_weights_time: float = 0.0
 
+    # DLPM metrics
+    dlpm_num_clients: int = 0
+
 
 class SchedulerMetricsCollector:
 
@@ -341,6 +344,14 @@ class SchedulerMetricsCollector:
         self.engine_load_weights_time = Gauge(
             name="sglang:engine_load_weights_time",
             documentation="The time taken for the engine to load weights.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+
+        # DLPM metrics
+        self.dlpm_num_clients = Gauge(
+            name="sglang:dlpm_num_clients",
+            documentation="The number of active DLPM clients being tracked.",
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
@@ -590,6 +601,9 @@ class SchedulerMetricsCollector:
             self._log_gauge(
                 self.engine_load_weights_time, stats.engine_load_weights_time
             )
+
+        # DLPM metrics
+        self._log_gauge(self.dlpm_num_clients, stats.dlpm_num_clients)
 
         self.last_log_time = time.perf_counter()
 

--- a/python/sglang/srt/metrics/collector.py
+++ b/python/sglang/srt/metrics/collector.py
@@ -176,6 +176,7 @@ class SchedulerStats:
     dlpm_num_clients: int = 0
     dlpm_top_clients: List[Tuple[str, int]] = field(default_factory=list)
     dlpm_needs_flush: bool = False
+    dlpm_refills_needed: int = 0
 
 class SchedulerMetricsCollector:
 
@@ -363,6 +364,12 @@ class SchedulerMetricsCollector:
             name="sglang:dlpm_top_clients_tokens",
             documentation="The tokens consumed by top DLPM clients since last metrics update.",
             labelnames=list(labels.keys()) + ["client"],
+            multiprocess_mode="mostrecent",
+        )
+        self.dlpm_refills_needed = Gauge(
+            name="sglang:dlpm_refills_needed",
+            documentation="The most refills needed before progress could be made.",
+            labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
 
@@ -614,6 +621,7 @@ class SchedulerMetricsCollector:
 
         # DLPM metrics
         self._log_gauge(self.dlpm_num_clients, stats.dlpm_num_clients)
+        self._log_gauge(self.dlpm_refills_needed, stats.dlpm_refills_needed)
 
         if stats.dlpm_needs_flush:
             stats.dlpm_needs_flush = False

--- a/python/sglang/srt/metrics/collector.py
+++ b/python/sglang/srt/metrics/collector.py
@@ -175,7 +175,7 @@ class SchedulerStats:
     # DLPM metrics
     dlpm_num_clients: int = 0
     dlpm_top_clients: List[Tuple[str, int]] = field(default_factory=list)
-
+    dlpm_needs_flush: bool = False
 
 class SchedulerMetricsCollector:
 
@@ -185,6 +185,9 @@ class SchedulerMetricsCollector:
 
         self.labels = labels
         self.last_log_time = time.perf_counter()
+
+        # Track known clients for zeroing out stale metrics
+        self.dlpm_known_clients = set()
 
         self.num_running_reqs = Gauge(
             name="sglang:num_running_reqs",
@@ -612,10 +615,22 @@ class SchedulerMetricsCollector:
         # DLPM metrics
         self._log_gauge(self.dlpm_num_clients, stats.dlpm_num_clients)
 
-        # Log top clients metrics with client_id label
-        for client_id, tokens_consumed in stats.dlpm_top_clients:
-            labels = {**self.labels, "client": client_id}
-            self.dlpm_top_clients_tokens.labels(**labels).set(tokens_consumed)
+        if stats.dlpm_needs_flush:
+            stats.dlpm_needs_flush = False
+
+            # Zero out metrics for clients that are no longer in top 10
+            current_top_clients = {client_id for client_id, _ in stats.dlpm_top_clients}
+            stale_clients = self.dlpm_known_clients - current_top_clients
+            for client_id in stale_clients:
+                labels = {**self.labels, "client": client_id}
+                self.dlpm_top_clients_tokens.labels(**labels).set(0)
+                self.dlpm_known_clients.remove(client_id)
+
+            # Set metrics for current top clients
+            for client_id, tokens_consumed in stats.dlpm_top_clients:
+                labels = {**self.labels, "client": client_id}
+                self.dlpm_top_clients_tokens.labels(**labels).set(tokens_consumed)
+                self.dlpm_known_clients.add(client_id)
 
         self.last_log_time = time.perf_counter()
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1339,7 +1339,7 @@ class ServerArgs:
             "--schedule-policy",
             type=str,
             default=ServerArgs.schedule_policy,
-            choices=["lpm", "random", "fcfs", "dfs-weight", "lof", "priority"],
+            choices=["lpm", "dlpm", "random", "fcfs", "dfs-weight", "lof", "priority"],
             help="The scheduling policy of the requests.",
         )
         parser.add_argument(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -182,6 +182,7 @@ class ServerArgs:
     schedule_low_priority_values_first: bool = False
     priority_scheduling_preemption_threshold: int = 10
     schedule_conservativeness: float = 1.0
+    dlpm_client_quantum: int = 2500
     page_size: Optional[int] = None
     hybrid_kvcache_ratio: Optional[float] = None
     swa_full_tokens_ratio: float = 0.8
@@ -1365,6 +1366,12 @@ class ServerArgs:
             type=float,
             default=ServerArgs.schedule_conservativeness,
             help="How conservative the schedule policy is. A larger value means more conservative scheduling. Use a larger value if you see requests being retracted frequently.",
+        )
+        parser.add_argument(
+            "--dlpm-client-quantum",
+            type=int,
+            default=ServerArgs.dlpm_client_quantum,
+            help="The quantum value for DLPM client deficit refill (default: 2500)",
         )
         parser.add_argument(
             "--page-size",


### PR DESCRIPTION
This implements the algorithm described in [Locality-aware Fair Scheduling in LLM Serving](https://arxiv.org/html/2501.14312v1) for the sglang scheduler.

The basic idea is this:

Instead of using a simple LPM mechanism (which can starve clients with e.g. unusual clients), we first sort queued requests as in LPM, and then proceed to account for the resources used by clients when actually admitting requests into batches. Clients are "billed" for tokens, and their requests are not admitted if their "budget" goes negative. Budgets are refilled once no more schedulable requests are available. I recommend reading the paper for details.

The paper doesn't specify the concrete implementation method, as this depends on the details of the inference server's scheduler. Our implementation in sglang works approximately like this:

1. On every scheduling round, we apply standard LPM sorting to requests. We retain the standard sglang behaviour that under high pressure (>=128 queue elements) LPM sorting is disabled, and FCFS is used. This makes scheduling less resource efficient under high-pressure, but the rest of the fairness guarantees are retained.
2. After sorting, we use an iterator function to yield consecutive, schedulable requests, accounting for the deficits. If the iterator could not yield any requests it runs the refilling logic.
3. We track per-user usage and other metrics (such as the minimum number of refills needed to progress) and export these to the monitoring system.

Currently the only configurable parameter is the refill quantum, which we are going to tune based on the metric indicating refills needed.

--------

For Yandex employees: See https://nda.ya.ru/t/9wHiYU6Y7KYZxq for the high-level ticket, and https://nda.ya.ru/t/fEpjMLSG7KYa3P for the metrics of inference servers currently running DLPM.